### PR TITLE
푸터 모달 메뉴 구현

### DIFF
--- a/eatnfit-FE/src/components/Footer/Footer.tsx
+++ b/eatnfit-FE/src/components/Footer/Footer.tsx
@@ -1,10 +1,19 @@
-import { WrappedFooter } from "./styles";
-import footerPlus from "../../img/footerPlus.png";
+import { useState } from "react";
+import { ModalMenuWrapper, WrappedFooter } from "./styles";
+import { BsPlusCircle } from "react-icons/bs";
+import { FooterModal } from "../FooterModal";
 
 const Footer = () => {
+  const [open, setOpen] = useState(false);
+
   return (
     <WrappedFooter>
-      <img src={footerPlus} width="30" />
+      <ModalMenuWrapper>{open && <FooterModal />}</ModalMenuWrapper>
+      <BsPlusCircle
+        size={"40px"}
+        onClick={() => setOpen(!open)}
+        className={open ? "open" : ""}
+      />
     </WrappedFooter>
   );
 };

--- a/eatnfit-FE/src/components/Footer/styles.ts
+++ b/eatnfit-FE/src/components/Footer/styles.ts
@@ -3,7 +3,19 @@ import styled from "styled-components";
 const WrappedFooter = styled.div`
   padding: 8px;
   display: flex;
+  flex-direction: column;
   justify-content: center;
+  align-items: center;
+
+  svg {
+    cursor: pointer;
+  }
+  .open {
+    opacity: 0.4;
+  }
 `;
 
-export { WrappedFooter };
+const ModalMenuWrapper = styled.div`
+  height: 170px;
+`;
+export { WrappedFooter, ModalMenuWrapper };

--- a/eatnfit-FE/src/components/FooterModal/FooterModal.tsx
+++ b/eatnfit-FE/src/components/FooterModal/FooterModal.tsx
@@ -1,0 +1,13 @@
+import { ModalWrapper } from "./styles";
+
+const FooterModal = () => {
+  return (
+    <ModalWrapper>
+      <p>식단</p>
+      <p>운동</p>
+      <p>계획</p>
+    </ModalWrapper>
+  );
+};
+
+export default FooterModal;

--- a/eatnfit-FE/src/components/FooterModal/FooterModal.tsx
+++ b/eatnfit-FE/src/components/FooterModal/FooterModal.tsx
@@ -1,11 +1,21 @@
-import { ModalWrapper } from "./styles";
+import { MenuItem, ModalWrapper } from "./styles";
+import { TbApple, TbRun, TbCheckupList } from "react-icons/tb";
 
 const FooterModal = () => {
   return (
     <ModalWrapper>
-      <p>식단</p>
-      <p>운동</p>
-      <p>계획</p>
+      <MenuItem>
+        <TbApple size={"23px"} />
+        <span>식단 추가</span>
+      </MenuItem>
+      <MenuItem>
+        <TbRun size={"23px"} />
+        <span>운동 추가</span>
+      </MenuItem>
+      <MenuItem>
+        <TbCheckupList size={"23px"} />
+        <span>계획 추가</span>
+      </MenuItem>
     </ModalWrapper>
   );
 };

--- a/eatnfit-FE/src/components/FooterModal/index.ts
+++ b/eatnfit-FE/src/components/FooterModal/index.ts
@@ -1,0 +1,1 @@
+export { default as FooterModal } from "./FooterModal";

--- a/eatnfit-FE/src/components/FooterModal/styles.ts
+++ b/eatnfit-FE/src/components/FooterModal/styles.ts
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+const ModalWrapper = styled.div`
+  text-align: center;
+`;
+
+export { ModalWrapper };

--- a/eatnfit-FE/src/components/FooterModal/styles.ts
+++ b/eatnfit-FE/src/components/FooterModal/styles.ts
@@ -2,6 +2,22 @@ import styled from "styled-components";
 
 const ModalWrapper = styled.div`
   text-align: center;
+  height: 180px;
 `;
 
-export { ModalWrapper };
+const MenuItem = styled.div`
+  border: 1px solid #89cff3;
+  color: #00a9ff;
+  padding: 15px;
+  font-size: 20px;
+  font-weight: 900;
+  display: flex;
+  justify-content: center;
+  cursor: pointer;
+  &:hover {
+    background-color: #89cff3;
+    color: white;
+  }
+`;
+
+export { ModalWrapper, MenuItem };

--- a/eatnfit-FE/src/components/index.ts
+++ b/eatnfit-FE/src/components/index.ts
@@ -17,3 +17,4 @@ export * from "./MainCalendar";
 export * from "./AddPlanButton";
 export * from "./PlanCheckboxes";
 export * from "./FoodChart";
+export * from "./FooterModal";


### PR DESCRIPTION
- footer 버튼 클릭 시 바로 위에 모달 메뉴 띄움
- footer 버튼 재클릭 시 모달 메뉴 숨김
- 모달 메뉴의 각 메뉴에 hover 추가
- 추후 footer의 위치 고정 필요 

<img width="200" alt="image" src="https://github.com/elice-cookcook/eatnfit/assets/33516975/7ba280fc-ebf0-49fb-86c5-29df74810d73">
<img width="200" alt="image" src="https://github.com/elice-cookcook/eatnfit/assets/33516975/9b19aecf-37cb-448e-96eb-c38fa5d97e49">
<img width="200" alt="image" src="https://github.com/elice-cookcook/eatnfit/assets/33516975/fa665dfd-79b4-4822-b934-6a3bae85a013">
