### PR TITLE
메인페이지 계획 get api hook 구현 & 데이터 바인딩

### DIFF
--- a/client/src/components/MainPlan/MainPlan.tsx
+++ b/client/src/components/MainPlan/MainPlan.tsx
@@ -1,20 +1,21 @@
+import { Spin } from "antd";
 import { AddPlanButton, Footer, PlanCheckboxes } from "..";
+import { useGetAllPlan } from "../../hooks";
 import { Container, ItemContainer } from "../MainFood/styles";
 import { Space } from "./styles";
 
 export default function MainPlan() {
-  const checkboxes = [
-    "공복 줄넘기",
-    "식단 잘 챙겨먹기",
-    "영양제 먹기",
-    "군것질 안하기",
-  ];
+  const { data, isLoading } = useGetAllPlan("20231031");
   return (
     <Container>
       <AddPlanButton />
       <ItemContainer>
         <Space>
-          <PlanCheckboxes items={checkboxes} />
+          {isLoading ? (
+            <Spin style={{ marginTop: "100px" }} />
+          ) : (
+            <PlanCheckboxes items={data?.map((item) => item.content)} />
+          )}
         </Space>
         <Footer />
       </ItemContainer>

--- a/client/src/components/PlanCheckboxes/PlanCheckboxes.tsx
+++ b/client/src/components/PlanCheckboxes/PlanCheckboxes.tsx
@@ -2,12 +2,12 @@ import { Container, StyledCheckbox } from "./styles";
 import { CloseOutlined } from "@ant-design/icons";
 
 type PlanCheckboxesType = {
-  items: string[];
+  items?: string[];
 };
 export default function PlanCheckboxes({ items }: PlanCheckboxesType) {
   return (
     <>
-      {items.map((item, idx) => {
+      {items?.map((item, idx) => {
         return (
           <Container key={idx}>
             <StyledCheckbox>{item}</StyledCheckbox>

--- a/client/src/hooks/getAllPlan.ts
+++ b/client/src/hooks/getAllPlan.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+import { useQuery } from 'react-query';
+import { Plan } from '../types';
+
+const getAllPlan = async (date: string): Promise<Plan[]> => {
+	const response = await axios.get(
+		`/api/v1/plans/${date}`
+	);
+	return response.data.data;
+};
+export function useGetAllPlan(date: string) {
+	return useQuery("get-all-plan", () => getAllPlan(date));
+}

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./getAllMeal";
+export * from "./getAllPlan";

--- a/client/src/types/Plan.ts
+++ b/client/src/types/Plan.ts
@@ -1,0 +1,7 @@
+export interface Plan {
+    _id: string;
+    date: number;
+    user_id: string;
+    content: string;
+    isComplete: number;
+}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from "./Meal";
+export * from "./Plan";


### PR DESCRIPTION
- 메인페이지 - 계획 컴포넌트의 getAllPlan api hook을 구현했습니다.
- custom hook을 통해 계획 컴포넌트에 데이터를 바인딩했습니다.
- 로딩중일 경우 react query의 isLoading을 통해 Spinner를 출력하도록 구현했습니다.