### PR TITLE
feat: Add postPlan custom hook and Apply post mutation

### DIFF
--- a/client/src/components/AddPlanButton/AddPlanButton.tsx
+++ b/client/src/components/AddPlanButton/AddPlanButton.tsx
@@ -1,11 +1,17 @@
 import { PlusCircleOutlined } from "@ant-design/icons";
+import { Dispatch, SetStateAction } from "react";
 import { Container, StyledTitle } from "./styles";
 
-export default function AddPlanButton() {
+type AddPlanButtonType = {
+  setAddPlan: Dispatch<SetStateAction<boolean>>;
+};
+export default function AddPlanButton({ setAddPlan }: AddPlanButtonType) {
   return (
     <Container>
       <PlusCircleOutlined />
-      <StyledTitle level={4}>계획을 추가해보세요.</StyledTitle>
+      <StyledTitle level={4} onClick={() => setAddPlan(true)}>
+        계획을 추가해보세요.
+      </StyledTitle>
     </Container>
   );
 }

--- a/client/src/components/AddPlanButton/AddPlanButton.tsx
+++ b/client/src/components/AddPlanButton/AddPlanButton.tsx
@@ -7,11 +7,9 @@ type AddPlanButtonType = {
 };
 export default function AddPlanButton({ setAddPlan }: AddPlanButtonType) {
   return (
-    <Container>
+    <Container onClick={() => setAddPlan(true)}>
       <PlusCircleOutlined />
-      <StyledTitle level={4} onClick={() => setAddPlan(true)}>
-        계획을 추가해보세요.
-      </StyledTitle>
+      <StyledTitle level={4}>계획을 추가해보세요.</StyledTitle>
     </Container>
   );
 }

--- a/client/src/components/AddPlanButton/styles.ts
+++ b/client/src/components/AddPlanButton/styles.ts
@@ -12,4 +12,5 @@ export const Container = styled.div`
 export const StyledTitle = styled(Title)`
     margin: 0 !important;
     color: #00a9ff !important;
+    cursor: pointer;
 `;

--- a/client/src/components/AddPlanButton/styles.ts
+++ b/client/src/components/AddPlanButton/styles.ts
@@ -8,9 +8,10 @@ export const Container = styled.div`
     align-items: center;
     font-size: 20px;
     gap: 4px;
+    width: 47%;
+    cursor: pointer;
 `;
 export const StyledTitle = styled(Title)`
     margin: 0 !important;
     color: #00a9ff !important;
-    cursor: pointer;
 `;

--- a/client/src/components/AddPlanCheckbox/AddPlanCheckbox.tsx
+++ b/client/src/components/AddPlanCheckbox/AddPlanCheckbox.tsx
@@ -1,0 +1,47 @@
+import { Container, StyledCheckbox } from "../PlanCheckboxes/styles";
+import { CloseOutlined } from "@ant-design/icons";
+import { StyledInput } from "./styles";
+import { Dispatch, SetStateAction, useState } from "react";
+import { usePostPlan } from "../../hooks";
+
+type AddPlanCheckboxType = {
+  setAddPlan: Dispatch<SetStateAction<boolean>>;
+};
+export default function AddPlanCheckbox({ setAddPlan }: AddPlanCheckboxType) {
+  const [focus, setFocus] = useState(true);
+  const [plan, setPlan] = useState("");
+  const { mutate } = usePostPlan("20231031", {
+    content: plan,
+    isComplete: 1,
+  });
+  const handlePostPlan = () => {
+    if (plan !== "") mutate();
+    setAddPlan(false);
+  };
+  return (
+    <Container>
+      {!focus ? (
+        <StyledCheckbox>
+          <StyledInput
+            onBlur={() => setFocus(false)}
+            value={plan}
+          ></StyledInput>
+          {}
+        </StyledCheckbox>
+      ) : (
+        <StyledInput
+          autoFocus
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            setPlan(e.target.value);
+          }}
+          onBlur={() => {
+            setFocus(false);
+            handlePostPlan();
+          }}
+        ></StyledInput>
+      )}
+
+      <CloseOutlined style={{ color: "#89cff3" }} />
+    </Container>
+  );
+}

--- a/client/src/components/AddPlanCheckbox/AddPlanCheckbox.tsx
+++ b/client/src/components/AddPlanCheckbox/AddPlanCheckbox.tsx
@@ -14,8 +14,17 @@ export default function AddPlanCheckbox({ setAddPlan }: AddPlanCheckboxType) {
     content: plan,
     isComplete: 1,
   });
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handlePostPlan();
+    }
+  };
+  const handleChange = (value: string) => {
+    setPlan(value);
+  };
   const handlePostPlan = () => {
     if (plan !== "") mutate();
+    setFocus(false);
     setAddPlan(false);
   };
   return (
@@ -31,11 +40,13 @@ export default function AddPlanCheckbox({ setAddPlan }: AddPlanCheckboxType) {
       ) : (
         <StyledInput
           autoFocus
+          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+            handleKeyDown(e);
+          }}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setPlan(e.target.value);
+            handleChange(e.target.value);
           }}
           onBlur={() => {
-            setFocus(false);
             handlePostPlan();
           }}
         ></StyledInput>

--- a/client/src/components/AddPlanCheckbox/index.ts
+++ b/client/src/components/AddPlanCheckbox/index.ts
@@ -1,0 +1,1 @@
+export { default as AddPlanCheckbox } from "./AddPlanCheckbox";

--- a/client/src/components/AddPlanCheckbox/styles.ts
+++ b/client/src/components/AddPlanCheckbox/styles.ts
@@ -1,0 +1,8 @@
+import { Input } from "antd";
+import styled from "styled-components";
+
+export const StyledInput = styled(Input)`
+    font-size: 20px;
+    padding: 0;
+    border: none;
+`;

--- a/client/src/components/MainPlan/MainPlan.tsx
+++ b/client/src/components/MainPlan/MainPlan.tsx
@@ -1,14 +1,17 @@
 import { Spin } from "antd";
+import { useState } from "react";
 import { AddPlanButton, Footer, PlanCheckboxes } from "..";
 import { useGetAllPlan } from "../../hooks";
+import { AddPlanCheckbox } from "../AddPlanCheckbox";
 import { Container, ItemContainer } from "../MainFood/styles";
 import { Space } from "./styles";
 
 export default function MainPlan() {
   const { data, isLoading } = useGetAllPlan("20231031");
+  const [addPlan, setAddPlan] = useState(false);
   return (
     <Container>
-      <AddPlanButton />
+      <AddPlanButton setAddPlan={setAddPlan} />
       <ItemContainer>
         <Space>
           {isLoading ? (
@@ -16,6 +19,7 @@ export default function MainPlan() {
           ) : (
             <PlanCheckboxes items={data?.map((item) => item.content)} />
           )}
+          {addPlan && <AddPlanCheckbox setAddPlan={setAddPlan} />}
         </Space>
         <Footer />
       </ItemContainer>

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -21,3 +21,4 @@ export * from "./FoodChart";
 export * from "./MainExercise";
 export * from "./MainFood";
 export * from "./MainPlan";
+export * from "./AddPlanCheckbox";

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./getAllMeal";
 export * from "./getAllPlan";
+export * from "./postPlan";

--- a/client/src/hooks/postPlan.ts
+++ b/client/src/hooks/postPlan.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import { useMutation, useQueryClient } from 'react-query';
+import { Plan, PlanContent } from '../types';
+
+const postPlan = async (date: string, plan: PlanContent): Promise<Plan> => {
+	const response = await axios.post(
+		`/api/v1/plans/${date}`, plan
+	);
+	return response.data;
+};
+export function usePostPlan(date: string, plan: PlanContent) {
+    const queryClient = useQueryClient();
+    return useMutation(() => postPlan(date, plan), {
+        onSuccess: () => {
+        queryClient.invalidateQueries("get-all-plan");
+    }});
+}

--- a/client/src/types/PlanContent.ts
+++ b/client/src/types/PlanContent.ts
@@ -1,0 +1,4 @@
+export interface PlanContent {
+    content: string;
+    isComplete: number;
+}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./Meal";
 export * from "./Plan";
+export * from "./PlanContent";

--- a/yarn.lock
+++ b/yarn.lock
@@ -677,7 +677,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -1314,7 +1314,7 @@
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
 
-"@typescript-eslint/parser@^6.0.0 || ^6.0.0-alpha", "@typescript-eslint/parser@^6.9.0":
+"@typescript-eslint/parser@^6.9.0":
   version "6.9.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.0.tgz"
   integrity sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==
@@ -1410,7 +1410,7 @@ acorn-walk@^8.1.1:
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz"
   integrity sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.4.1, acorn@^8.9.0:
+acorn@^8.4.1, acorn@^8.9.0:
   version "8.11.2"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz"
   integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
@@ -1801,26 +1801,26 @@ date-fns@^2.30.0:
   dependencies:
     "@babel/runtime" "^7.21.0"
 
-debug@^3.2.7:
-  version "3.2.7"
-  resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
-  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.1.1, debug@^4.3.2, debug@^4.3.4, debug@4.x:
-  version "4.3.4"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
-
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@4.x, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -2074,7 +2074,7 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-"eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^7.0.0 || ^8.0.0", eslint@^8.52.0, eslint@>=7.0.0, eslint@>=8.0.0:
+eslint@^8.52.0:
   version "8.52.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz"
   integrity sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==
@@ -3012,15 +3012,15 @@ mquery@5.0.0:
   dependencies:
     debug "4.x"
 
-ms@^2.1.1, ms@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
-  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
+
+ms@2.1.2, ms@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 ms@2.1.3:
   version "2.1.3"
@@ -3283,7 +3283,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^3.0.3, prettier@>=3.0.0:
+prettier@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz"
   integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
@@ -3879,7 +3879,6 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
-typescript@^5.2.2, typescript@>=2.7, typescript@>=4.2.0:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -3910,7 +3909,7 @@ undici-types@~5.26.4:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
-unpipe@~1.0.0, unpipe@1.0.0:
+unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==


### PR DESCRIPTION
1. postPlan api custom hook을 구현했습니다. useMutation과 queryClient를 통해 onSuccess의 경우 plan의 get api를 바로 호출할 수 있도록 작성했습니다.
2. 계획을 추가해주세요. 텍스트를 클릭 시 계획 리스트 하단에 input 형태로 된 계획 추가 컴포넌트가 나타납니다.
3. focus 상태를 벗어나면 좌측에 체크박스가 생기고 리스트에 추가됩니다.