### PR TITLE
식단 get api 수정 & 메인페이지 식단 데이터 바인딩

### DIFF
--- a/client/src/components/FoodChart/FoodChart.tsx
+++ b/client/src/components/FoodChart/FoodChart.tsx
@@ -1,13 +1,16 @@
 import { Chart as ChartJS, ArcElement, Tooltip } from "chart.js";
 import { Pie } from "react-chartjs-2";
 
-export default function FoodChart() {
+type FoodChartType = {
+  description: number[];
+};
+export default function FoodChart({ description }: FoodChartType) {
   ChartJS.register(ArcElement, Tooltip);
   const data = {
     labels: ["탄수화물", "단백질", "지방"],
     datasets: [
       {
-        data: [60, 20, 10],
+        data: description,
         backgroundColor: [
           "rgba(255, 99, 132, 0.2)",
           "rgba(54, 162, 235, 0.2)",

--- a/client/src/components/MainFood/MainFood.tsx
+++ b/client/src/components/MainFood/MainFood.tsx
@@ -1,48 +1,75 @@
-import { Divider } from "antd";
+import { Divider, Spin } from "antd";
 import { Dashboard, FoodChart, Footer, MainFoodItems } from "..";
+import { useGetAllMeal } from "../../hooks";
 import { Container, FlexBox, ItemContainer, Space } from "./styles";
 
 export default function MainFood() {
-  const foodList = [
-    [
-      { type: "아침", time: "08:15", name: "삶은 계란", kcal: 90, count: 2 },
-      { type: "아침", time: "08:15", name: "사과", kcal: 120, count: 1 },
-    ],
-    [
-      { type: "점심", time: "13:15", name: "고구마", kcal: 110, count: 2 },
-      { type: "점심", time: "13:15", name: "새우 샐러드", kcal: 120, count: 1 },
-    ],
-    // [
-    //   { type: "간식", time: "16:15", name: "바나나", kcal: 80, count: 1 },
-    //   { type: "간식", time: "16:15", name: "아몬드", kcal: 140, count: 1 },
-    // ],
-    [
-      {
-        type: "저녁",
-        time: "18:15",
-        name: "프로틴 쉐이크",
-        kcal: 80,
-        count: 1,
-      },
-      { type: "저녁", time: "18:15", name: "닭가슴살", kcal: 110, count: 1 },
-    ],
-  ];
+  const { data, isLoading } = useGetAllMeal("20231031");
+  type FoodListType = {
+    type: string;
+    time: string;
+    name: string;
+    kcal: number;
+    count: number;
+  };
+  const mealType = ["아침", "아점", "점심", "간식", "점저", "저녁", "야식"];
+  const foodList: FoodListType[][] = [];
+  const kcal: number[] = [];
+  const carbohydrate: number[] = [];
+  const protein: number[] = [];
+  const fat: number[] = [];
+
+  if (!isLoading) {
+    data?.map((item) => {
+      item.items.map((list) => {
+        foodList.push([
+          {
+            type: mealType[item.meal_type],
+            time: `${String(item.time).slice(0, 2)}:${String(item.time).slice(
+              2
+            )}`,
+            name: list.item,
+            kcal: list.kcal,
+            count: list.count,
+          },
+        ]);
+      });
+      kcal.push(item.total_kcal);
+      carbohydrate.push(item.total_carbohydrate);
+      protein.push(item.total_protein);
+      fat.push(item.total_fat);
+    });
+  }
+  const [totalCarbohydrate, totalProtein, totalFat] = [
+    carbohydrate,
+    protein,
+    fat,
+  ].map((item) => item.reduce((acc, cur) => acc + cur, 0));
   return (
     <Container>
       <FlexBox>
         <Dashboard
           title={["탄수화물", "단백질", "지방"]}
-          description={["40g", "20g", "10g"]}
+          description={[
+            `${totalCarbohydrate}g`,
+            `${totalProtein}g`,
+            `${totalFat}g`,
+          ]}
           width={55}
           color={["#ff6384", "#36a2eb", "#47c83e"]}
         />
-        <FoodChart />
+        <FoodChart description={[totalCarbohydrate, totalProtein, totalFat]} />
       </FlexBox>
       <Divider />
       <ItemContainer>
-        <Space>
-          <MainFoodItems items={foodList} />
-        </Space>
+        {isLoading ? (
+          <Spin />
+        ) : (
+          <Space>
+            <MainFoodItems items={foodList} totalKcal={kcal} />
+          </Space>
+        )}
+
         <Footer />
       </ItemContainer>
     </Container>

--- a/client/src/components/MainFoodItems/MainFoodItems.tsx
+++ b/client/src/components/MainFoodItems/MainFoodItems.tsx
@@ -17,13 +17,12 @@ type MainFoodItemsType = {
     kcal: number;
     count: number;
   }[][];
+  totalKcal: number[];
 };
-export default function MainFoodItems({ items }: MainFoodItemsType) {
-  let totalKcal = 0;
+export default function MainFoodItems({ items, totalKcal }: MainFoodItemsType) {
   return (
     <>
       {items.map((item, idx) => {
-        totalKcal = 0;
         return (
           <Container key={idx}>
             <Image src="https://i.ibb.co/F3KM2tt/998-D65415-D2-FB70128.jpg"></Image>
@@ -34,7 +33,6 @@ export default function MainFoodItems({ items }: MainFoodItemsType) {
               </TitleBlock>
               <StyledList>
                 {item.map((list, idx) => {
-                  totalKcal += list.kcal * list.count;
                   return (
                     <li key={idx}>
                       <FlexBox>
@@ -45,7 +43,7 @@ export default function MainFoodItems({ items }: MainFoodItemsType) {
                   );
                 })}
                 <Space>
-                  총합 <strong>{totalKcal}</strong>kcal
+                  총합 <strong>{totalKcal[idx]}</strong>kcal
                 </Space>
               </StyledList>
             </Contents>

--- a/client/src/hooks/getAllMeal.ts
+++ b/client/src/hooks/getAllMeal.ts
@@ -2,11 +2,11 @@ import axios from 'axios';
 import { useQuery } from 'react-query';
 import { Meal } from '../types';
 
-const getAllMeal = async (date: string): Promise<Meal> => {
+const getAllMeal = async (date: string): Promise<Meal[]> => {
 	const response = await axios.get(
 		`/api/v1/meals/${date}`
 	);
-	return response.data;
+	return response.data.data;
 };
 export function useGetAllMeal(date: string) {
 	return useQuery("get-all-meal", () => getAllMeal(date));

--- a/client/src/types/Meal.ts
+++ b/client/src/types/Meal.ts
@@ -6,8 +6,13 @@ export interface Meal {
     meal_type: number;
     image_url: string;
     total_kcal: number;
-    items: {
+    items: [{
         _id: string;
+        item: string;
         count: number;
-    }
+        kcal: number;
+    }],
+    total_carbohydrate: number,
+    total_fat: number,
+    total_protein: number,
 }


### PR DESCRIPTION
1. api 명세에 맞추어 useGetAllMeal custom hook의 형식을 변경했습니다. (items 배열로 분리, 탄단지 추가)
2. 메인페이지 - 식단 컴포넌트에 useGetAllMeal()의 데이터를 매핑하였습니다.
![image](https://github.com/elice-cookcook/eatnfit/assets/87300419/cdaae1ec-f863-4f63-8e62-39df9ee7d2cb)
3. 탄단지 대시보드 테이블과 원형차트에 탄단지 데이터를 매핑하였습니다.
![image](https://github.com/elice-cookcook/eatnfit/assets/87300419/cbecbd93-cb0d-4213-922c-5bfc41edd9ca)
