### PR TITLE
운동 검색 페이지에서 운동 이름 전달 기능 구현

### DIFF
--- a/client/src/components/SearchAddItem/SearchAddItem.tsx
+++ b/client/src/components/SearchAddItem/SearchAddItem.tsx
@@ -1,0 +1,20 @@
+import { Container, ItemContainer, Img } from "./styles";
+import CloseImage from "../../img/close.png";
+
+type SearchAddItemProps = {
+  selectedItemNames?: string[];
+  onDeleteItem: (idx: number) => void;
+};
+
+export default function SearchAddItem(props: SearchAddItemProps) {
+  return (
+    <Container>
+      {props.selectedItemNames?.map((item, idx) => (
+        <ItemContainer key={`${item}-${idx}`}>
+          <div>{item}</div>
+          <Img src={CloseImage} onClick={() => props.onDeleteItem(idx)} />
+        </ItemContainer>
+      ))}
+    </Container>
+  );
+}

--- a/client/src/components/SearchAddItem/index.ts
+++ b/client/src/components/SearchAddItem/index.ts
@@ -1,0 +1,1 @@
+export { default as SearchAddItem } from "./SearchAddItem";

--- a/client/src/components/SearchAddItem/styles.ts
+++ b/client/src/components/SearchAddItem/styles.ts
@@ -1,0 +1,27 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  margin: 4px 10px;
+  flex-wrap: wrap;
+`;
+
+export const ItemContainer = styled.div`
+  background-color: #e0ebff;
+  border-radius: 10px;
+  border: none;
+  padding: 4px 10px;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  margin-right: 4px;
+  margin-bottom: 4px;
+`;
+
+export const Img = styled.img`
+  width: 10px;
+  height: 10px;
+  margin-left: 4px;
+  cursor: pointer;
+`;

--- a/client/src/components/SearchItems/SearchItems.tsx
+++ b/client/src/components/SearchItems/SearchItems.tsx
@@ -3,6 +3,8 @@ import AddImg from "../../img/footerPlus.png";
 
 type SearchItemsProps = {
   items?: { id?: string; name: string; calory?: number }[];
+  selectedItemNames: string[];
+  onAddItem: (itemName: string[]) => void;
 };
 
 function SearchItems(props: SearchItemsProps) {
@@ -13,6 +15,12 @@ function SearchItems(props: SearchItemsProps) {
       </div>
     );
   }
+
+  const handleAddItem = (itemName: string) => {
+    const updatedItemNames = [...props.selectedItemNames, itemName];
+    props.onAddItem(updatedItemNames);
+  };
+
   return props.items?.map((item) => (
     <WrappedSearchItems key={item.name}>
       <Context>
@@ -20,7 +28,11 @@ function SearchItems(props: SearchItemsProps) {
         {item.calory && <Calory>{item.calory}kcal, 1회 제공량</Calory>}
       </Context>
       <Image>
-        <img src={AddImg} width="24px" />
+        <img
+          src={AddImg}
+          width="24px"
+          onClick={() => handleAddItem(item.name)}
+        />
       </Image>
     </WrappedSearchItems>
   ));

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -22,3 +22,4 @@ export * from "./MainExercise";
 export * from "./MainFood";
 export * from "./MainPlan";
 export * from "./AddPlanCheckbox";
+export * from "./SearchAddItem";

--- a/client/src/pages/ExerciseRecordPage/ExerciseRecordPage.tsx
+++ b/client/src/pages/ExerciseRecordPage/ExerciseRecordPage.tsx
@@ -5,9 +5,10 @@ import {
   Title,
   FormItemContainer,
   Input,
+  PTag,
   HeaderTitle,
 } from "./styles";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import {
   CloseBtn,
   SubmitBtn,
@@ -28,7 +29,8 @@ import { useSelector } from "react-redux";
 import { RootState } from "../../redux";
 
 export default function ExerciseRecordPage() {
-  const [exerciseName, setExerciseName] = useState(""); // 데이터 검색으로 추가하여 수정, 일단 인풋 받음
+  const location = useLocation();
+  const exerciseName = location.state?.exerciseName || "";
   const [exerciseTime, setExerciseTime] = useState<number>(0);
   const [exerciseType, setExerciseType] = useState<number>(0);
   const [exercisePart, setExercisePart] = useState<number>(0);
@@ -68,11 +70,7 @@ export default function ExerciseRecordPage() {
         </Link>
         <FormItemContainer className="name">
           <Title>운동명</Title>
-          <Input
-            value={exerciseName}
-            onChange={(e) => setExerciseName(e.target.value)}
-            placeholder="운동 이름을 입력해주세요."
-          ></Input>
+          <PTag>{exerciseName}</PTag>
         </FormItemContainer>
         <FormItemContainer className="time">
           <Title>운동 시간</Title>

--- a/client/src/pages/ExerciseRecordPage/styles.ts
+++ b/client/src/pages/ExerciseRecordPage/styles.ts
@@ -41,6 +41,12 @@ const Title = styled.h4`
   padding: 5px;
 `;
 
+const PTag = styled.p`
+  padding: 5px;
+  margin: 0;
+  color: gray;
+`;
+
 const Input = styled.input`
   width: 60%;
   padding: 10px;
@@ -55,4 +61,5 @@ export {
   FormItemContainer,
   Title,
   Input,
+  PTag,
 };

--- a/client/src/pages/SearchExercisePage/SearchExercisePage.tsx
+++ b/client/src/pages/SearchExercisePage/SearchExercisePage.tsx
@@ -1,15 +1,17 @@
 import { Wrap, SearchHeader, SearchMain, LinkToAddFood, Items } from "./styles";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import {
   CloseBtn,
   SubmitBtn,
   SearchInput,
   LongBtn,
+  SearchAddItem,
   SearchItems,
   Footer,
 } from "../../components";
 import { Spin } from "antd";
 import { useGetAllActivity } from "../../hooks";
+import { useState } from "react";
 
 export default function SearchExercisePage() {
   const { data, isLoading } = useGetAllActivity();
@@ -18,11 +20,37 @@ export default function SearchExercisePage() {
     name: item.name,
   }));
 
+  // 선택한 아이템들의 이름을 담는 상태
+  const [selectedItemNames, setSelectedItemNames] = useState<string[]>([]);
+  const nav = useNavigate();
+
+  // 아이템 추가
+  const handleAddItem = (itemNames: string[]) => {
+    setSelectedItemNames(itemNames);
+  };
+
+  // 아이템 삭제
+  const handleDeleteItem = (idx: number) => {
+    const updatedItemNames = [...selectedItemNames];
+    updatedItemNames.splice(idx, 1);
+    setSelectedItemNames(updatedItemNames);
+  };
+
+  const handlePost = () => {
+    // 운동만 1개로 제한
+    if (selectedItemNames.length > 1) {
+      alert("보다 정확한 소모 칼로리 계산을 위해 한가지만 선택해주세요☺️");
+      return;
+    }
+    // 기록 페이지에 운동 이름 전달
+    nav("/exerciserecord", { state: { exerciseName: selectedItemNames[0] } });
+  };
+
   return (
     <Wrap>
       <SearchHeader>
         <CloseBtn />
-        <SubmitBtn />
+        <SubmitBtn onSubmit={handlePost} />
       </SearchHeader>
       <SearchMain>
         <h2>운동 검색</h2>
@@ -32,11 +60,19 @@ export default function SearchExercisePage() {
             <LongBtn text="직접 추가하기(운동명, 시간)" />
           </Link>
         </LinkToAddFood>
+        <SearchAddItem
+          selectedItemNames={selectedItemNames}
+          onDeleteItem={handleDeleteItem}
+        />
         {isLoading ? (
           <Spin style={{ marginTop: "100px", marginLeft: "200px" }} />
         ) : (
           <Items>
-            <SearchItems items={items} />
+            <SearchItems
+              items={items}
+              selectedItemNames={selectedItemNames}
+              onAddItem={handleAddItem}
+            />
           </Items>
         )}
       </SearchMain>

--- a/client/src/pages/SearchExercisePage/SearchExercisePage.tsx
+++ b/client/src/pages/SearchExercisePage/SearchExercisePage.tsx
@@ -1,4 +1,11 @@
-import { Wrap, SearchHeader, SearchMain, LinkToAddFood, Items } from "./styles";
+import {
+  Wrap,
+  SearchHeader,
+  SearchMain,
+  LinkToAddFood,
+  Items,
+  PTag,
+} from "./styles";
 import { Link, useNavigate } from "react-router-dom";
 import {
   CloseBtn,
@@ -24,11 +31,6 @@ export default function SearchExercisePage() {
   const [selectedItemNames, setSelectedItemNames] = useState<string[]>([]);
   const nav = useNavigate();
 
-  // 아이템 추가
-  const handleAddItem = (itemNames: string[]) => {
-    setSelectedItemNames(itemNames);
-  };
-
   // 아이템 삭제
   const handleDeleteItem = (idx: number) => {
     const updatedItemNames = [...selectedItemNames];
@@ -37,13 +39,10 @@ export default function SearchExercisePage() {
   };
 
   const handlePost = () => {
-    // 운동만 1개로 제한
-    if (selectedItemNames.length > 1) {
-      alert("보다 정확한 소모 칼로리 계산을 위해 한가지만 선택해주세요☺️");
-      return;
-    }
+    const exerciseNameToSend =
+      selectedItemNames.length > 0 ? selectedItemNames[0] : "";
     // 기록 페이지에 운동 이름 전달
-    nav("/exerciserecord", { state: { exerciseName: selectedItemNames[0] } });
+    nav("/exerciserecord", { state: { exerciseName: exerciseNameToSend } });
   };
 
   return (
@@ -64,6 +63,13 @@ export default function SearchExercisePage() {
           selectedItemNames={selectedItemNames}
           onDeleteItem={handleDeleteItem}
         />
+        {selectedItemNames.length > 1 ? (
+          <PTag>
+            보다 정확한 소모 칼로리 계산을 위해 한가지만 선택해주세요☺️
+          </PTag>
+        ) : (
+          ""
+        )}
         {isLoading ? (
           <Spin style={{ marginTop: "100px", marginLeft: "200px" }} />
         ) : (
@@ -71,7 +77,7 @@ export default function SearchExercisePage() {
             <SearchItems
               items={items}
               selectedItemNames={selectedItemNames}
-              onAddItem={handleAddItem}
+              onAddItem={setSelectedItemNames}
             />
           </Items>
         )}

--- a/client/src/pages/SearchExercisePage/styles.ts
+++ b/client/src/pages/SearchExercisePage/styles.ts
@@ -36,4 +36,10 @@ const Items = styled.div`
   }
 `;
 
-export { Wrap, SearchHeader, SearchMain, LinkToAddFood, Items };
+const PTag = styled.p`
+  font-size: 14px;
+  text-align: center;
+  color: #787878;
+`;
+
+export { Wrap, SearchHeader, SearchMain, LinkToAddFood, Items, PTag };


### PR DESCRIPTION
### 운동 검색 페이지__+ 버튼 클릭 => 목록 위에 해당 아이템이 추가됨 (현재는 이름만 추가)
<img width="302" alt="image" src="https://github.com/elice-cookcook/eatnfit/assets/109502469/a5561c33-e93f-4b34-88c9-518ec1bae627">

> X 버튼을 누르면 삭제

* 운동은 한개씩 추가하도록 구현 (여러개를 클릭하면 메시지가 뜨게끔)
<img width="353" alt="image" src="https://github.com/elice-cookcook/eatnfit/assets/109502469/3103508a-1022-46fd-a8ad-d3cd4ae73016">


* 등록 버튼 클릭 => 운동 기록 페이지로 이동 (이때, 해당 운동 명도 같이 전달해줌 => 여러 개 선택 => 첫 번째 값)

### 운동 기록 페이지
아래 사진과 같이 운동 명이 자동으로 추가되는 것을 확인할 수 있음
<img width="321" alt="image" src="https://github.com/elice-cookcook/eatnfit/assets/109502469/aae38b76-6a74-4477-a14f-af9e2cc76c13">
