### PR TITLE
계획 삭제, 수정 기능 구현

### DIFF
--- a/client/src/components/AddPlanCheckbox/AddPlanCheckbox.tsx
+++ b/client/src/components/AddPlanCheckbox/AddPlanCheckbox.tsx
@@ -1,8 +1,9 @@
-import { Container, StyledCheckbox } from "../PlanCheckboxes/styles";
+import { Container } from "../PlanCheckboxes/styles";
 import { CloseOutlined } from "@ant-design/icons";
 import { StyledInput } from "./styles";
 import { Dispatch, SetStateAction, useState } from "react";
 import { usePostPlan } from "../../hooks";
+import { Checkbox } from "antd";
 
 type AddPlanCheckboxType = {
   setAddPlan: Dispatch<SetStateAction<boolean>>;
@@ -30,13 +31,13 @@ export default function AddPlanCheckbox({ setAddPlan }: AddPlanCheckboxType) {
   return (
     <Container>
       {!focus ? (
-        <StyledCheckbox>
+        <Checkbox>
           <StyledInput
             onBlur={() => setFocus(false)}
             value={plan}
           ></StyledInput>
           {}
-        </StyledCheckbox>
+        </Checkbox>
       ) : (
         <StyledInput
           autoFocus

--- a/client/src/components/AddPlanCheckbox/AddPlanCheckbox.tsx
+++ b/client/src/components/AddPlanCheckbox/AddPlanCheckbox.tsx
@@ -7,11 +7,12 @@ import { Checkbox } from "antd";
 
 type AddPlanCheckboxType = {
   setAddPlan: Dispatch<SetStateAction<boolean>>;
+  activeDay: string;
 };
-export default function AddPlanCheckbox({ setAddPlan }: AddPlanCheckboxType) {
+export default function AddPlanCheckbox({ setAddPlan, activeDay }: AddPlanCheckboxType) {
   const [focus, setFocus] = useState(true);
   const [plan, setPlan] = useState("");
-  const { mutate } = usePostPlan("20231031", {
+  const { mutate } = usePostPlan(activeDay, {
     content: plan,
     isComplete: 1,
   });

--- a/client/src/components/AddedItems/AddedItems.tsx
+++ b/client/src/components/AddedItems/AddedItems.tsx
@@ -40,7 +40,7 @@ function AddedItems(props: AddedItemsProps) {
       })
     );
     newFood[index].quantity = newValue;
-    newFood[index].calory = Number(items[index].baseCalory) * newValue;
+    newFood[index].calory = Number(items[index].baseCalory);
     dispatch(setFood(newFood));
   };
 

--- a/client/src/components/MainPlan/MainPlan.tsx
+++ b/client/src/components/MainPlan/MainPlan.tsx
@@ -14,14 +14,18 @@ export default function MainPlan() {
       <AddPlanButton setAddPlan={setAddPlan} />
       <ItemContainer>
         <Space>
-          {isLoading ? (
-            <Spin style={{ marginTop: "100px" }} />
-          ) : Number(data?.length) <= 0 && !addPlan ? (
-            <div style={{ marginTop: "120px" }}>등록된 계획이 없습니다.</div>
-          ) : (
-            <PlanCheckboxes items={data} />
-          )}
-          {addPlan && <AddPlanCheckbox setAddPlan={setAddPlan} />}
+          <>
+            {isLoading ? (
+              <Spin style={{ marginTop: "100px" }} />
+            ) : Number(data?.length) <= 0 && !addPlan ? (
+              <div style={{ marginTop: "120px" }}>등록된 계획이 없습니다.</div>
+            ) : (
+              data?.map((item) => {
+                return <PlanCheckboxes item={item} />;
+              })
+            )}
+            {addPlan && <AddPlanCheckbox setAddPlan={setAddPlan} />}
+          </>
         </Space>
         <Footer />
       </ItemContainer>

--- a/client/src/components/MainPlan/MainPlan.tsx
+++ b/client/src/components/MainPlan/MainPlan.tsx
@@ -16,8 +16,10 @@ export default function MainPlan() {
         <Space>
           {isLoading ? (
             <Spin style={{ marginTop: "100px" }} />
+          ) : Number(data?.length) <= 0 && !addPlan ? (
+            <div style={{ marginTop: "120px" }}>등록된 계획이 없습니다.</div>
           ) : (
-            <PlanCheckboxes items={data?.map((item) => item.content)} />
+            <PlanCheckboxes items={data} />
           )}
           {addPlan && <AddPlanCheckbox setAddPlan={setAddPlan} />}
         </Space>

--- a/client/src/components/MainPlan/MainPlan.tsx
+++ b/client/src/components/MainPlan/MainPlan.tsx
@@ -5,9 +5,14 @@ import { useGetAllPlan } from "../../hooks";
 import { AddPlanCheckbox } from "../AddPlanCheckbox";
 import { Container, ItemContainer } from "../MainFood/styles";
 import { Space } from "./styles";
+import { RootState } from "../../redux";
+import { useSelector } from "react-redux";
 
 export default function MainPlan() {
-  const { data, isLoading } = useGetAllPlan("20231031");
+  const activeDay = useSelector(
+    (state: RootState) => state.activeDay.activeDay
+  );
+  const { data, isLoading } = useGetAllPlan(activeDay);
   const [addPlan, setAddPlan] = useState(false);
   return (
     <Container>
@@ -21,10 +26,10 @@ export default function MainPlan() {
               <div style={{ marginTop: "120px" }}>등록된 계획이 없습니다.</div>
             ) : (
               data?.map((item) => {
-                return <PlanCheckboxes item={item} />;
+                return <PlanCheckboxes item={item} activeDay={activeDay} />;
               })
             )}
-            {addPlan && <AddPlanCheckbox setAddPlan={setAddPlan} />}
+            {addPlan && <AddPlanCheckbox setAddPlan={setAddPlan} activeDay={activeDay} />}
           </>
         </Space>
         <Footer />

--- a/client/src/components/PlanCheckboxes/PlanCheckboxes.tsx
+++ b/client/src/components/PlanCheckboxes/PlanCheckboxes.tsx
@@ -1,8 +1,9 @@
+import { Plan } from "../../types";
+import { DeletePlanButton } from "../deletePlanButton";
 import { Container, StyledCheckbox } from "./styles";
-import { CloseOutlined } from "@ant-design/icons";
 
 type PlanCheckboxesType = {
-  items?: string[];
+  items?: Plan[] | undefined;
 };
 export default function PlanCheckboxes({ items }: PlanCheckboxesType) {
   return (
@@ -10,8 +11,8 @@ export default function PlanCheckboxes({ items }: PlanCheckboxesType) {
       {items?.map((item, idx) => {
         return (
           <Container key={idx}>
-            <StyledCheckbox>{item}</StyledCheckbox>
-            <CloseOutlined style={{ color: "#89cff3" }} />
+            <StyledCheckbox>{item.content}</StyledCheckbox>
+            <DeletePlanButton id={item._id} />
           </Container>
         );
       })}

--- a/client/src/components/PlanCheckboxes/PlanCheckboxes.tsx
+++ b/client/src/components/PlanCheckboxes/PlanCheckboxes.tsx
@@ -1,21 +1,32 @@
+import { Checkbox } from "antd";
+import { useState } from "react";
+import { usePatchPlan } from "../../hooks/patchPlan";
 import { Plan } from "../../types";
 import { DeletePlanButton } from "../deletePlanButton";
-import { Container, StyledCheckbox } from "./styles";
+import { Container, Content } from "./styles";
 
 type PlanCheckboxesType = {
-  items?: Plan[] | undefined;
+  item?: Plan | undefined;
 };
-export default function PlanCheckboxes({ items }: PlanCheckboxesType) {
+
+export default function PlanCheckboxes({ item }: PlanCheckboxesType) {
+  const [isChecked, setIsChecked] = useState(
+    item?.isComplete === 0 ? true : false
+  );
+  const { mutate } = usePatchPlan("20231031", item?._id, {
+    content: item?.content,
+    isComplete: isChecked ? 1 : 0,
+  });
+  const handleChange = () => {
+    setIsChecked(!isChecked);
+    mutate();
+  };
   return (
-    <>
-      {items?.map((item, idx) => {
-        return (
-          <Container key={idx}>
-            <StyledCheckbox>{item.content}</StyledCheckbox>
-            <DeletePlanButton id={item._id} />
-          </Container>
-        );
-      })}
-    </>
+    <Container>
+      <Checkbox onChange={handleChange} checked={isChecked}>
+        <Content isChecked={isChecked}>{item?.content}</Content>
+      </Checkbox>
+      <DeletePlanButton id={item?._id} />
+    </Container>
   );
 }

--- a/client/src/components/PlanCheckboxes/PlanCheckboxes.tsx
+++ b/client/src/components/PlanCheckboxes/PlanCheckboxes.tsx
@@ -1,5 +1,4 @@
 import { Checkbox } from "antd";
-import { useState } from "react";
 import { usePatchPlan } from "../../hooks/patchPlan";
 import { Plan } from "../../types";
 import { DeletePlanButton } from "../deletePlanButton";
@@ -7,24 +6,21 @@ import { Container, Content } from "./styles";
 
 type PlanCheckboxesType = {
   item?: Plan | undefined;
+  activeDay: string;
 };
 
-export default function PlanCheckboxes({ item }: PlanCheckboxesType) {
-  const [isChecked, setIsChecked] = useState(
-    item?.isComplete === 0 ? true : false
-  );
-  const { mutate } = usePatchPlan("20231031", item?._id, {
+export default function PlanCheckboxes({ item, activeDay }: PlanCheckboxesType) {
+  const { mutate } = usePatchPlan(activeDay, item?._id, {
     content: item?.content,
-    isComplete: isChecked ? 1 : 0,
+    isComplete: item?.isComplete === 0 ? 1 : 0,
   });
   const handleChange = () => {
-    setIsChecked(!isChecked);
     mutate();
   };
   return (
     <Container>
-      <Checkbox onChange={handleChange} checked={isChecked}>
-        <Content isChecked={isChecked}>{item?.content}</Content>
+      <Checkbox onChange={handleChange} checked={item?.isComplete === 0 ? true : false}>
+        <Content isChecked={item?.isComplete === 0 ? true : false}>{item?.content}</Content>
       </Checkbox>
       <DeletePlanButton id={item?._id} />
     </Container>

--- a/client/src/components/PlanCheckboxes/styles.ts
+++ b/client/src/components/PlanCheckboxes/styles.ts
@@ -5,6 +5,7 @@ interface StyledCheckboxProps {
 export const Content = styled.div<StyledCheckboxProps>`
     font-size: 20px !important;
     text-decoration: ${({ isChecked }) => (isChecked ? 'line-through' : 'none')};
+    color: ${({ isChecked }) => (isChecked ? '#ccc' : 'initial')};
     }};
 `;
 export const Container = styled.div`

--- a/client/src/components/PlanCheckboxes/styles.ts
+++ b/client/src/components/PlanCheckboxes/styles.ts
@@ -1,10 +1,11 @@
-import { Checkbox } from "antd";
 import styled from "styled-components";
-
-export const StyledCheckbox = styled(Checkbox)`
-    span {
-        font-size: 20px !important;
-    }
+interface StyledCheckboxProps {
+    isChecked: boolean;
+  }
+export const Content = styled.div<StyledCheckboxProps>`
+    font-size: 20px !important;
+    text-decoration: ${({ isChecked }) => (isChecked ? 'line-through' : 'none')};
+    }};
 `;
 export const Container = styled.div`
     display: flex;

--- a/client/src/components/deletePlanButton/DeletePlanButton.tsx
+++ b/client/src/components/deletePlanButton/DeletePlanButton.tsx
@@ -1,0 +1,15 @@
+import { CloseOutlined } from "@ant-design/icons";
+import { useDeletePlan } from "../../hooks";
+
+type DeletePlanButtonType = {
+  id: string;
+};
+export default function DeletePlanButton({ id }: DeletePlanButtonType) {
+  const { mutate } = useDeletePlan(id);
+  const handleClose = () => {
+    mutate();
+  };
+  return (
+    <CloseOutlined style={{ color: "#89cff3" }} onClick={() => handleClose()} />
+  );
+}

--- a/client/src/components/deletePlanButton/DeletePlanButton.tsx
+++ b/client/src/components/deletePlanButton/DeletePlanButton.tsx
@@ -2,7 +2,7 @@ import { CloseOutlined } from "@ant-design/icons";
 import { useDeletePlan } from "../../hooks";
 
 type DeletePlanButtonType = {
-  id: string;
+  id: string | undefined;
 };
 export default function DeletePlanButton({ id }: DeletePlanButtonType) {
   const { mutate } = useDeletePlan(id);

--- a/client/src/components/deletePlanButton/index.ts
+++ b/client/src/components/deletePlanButton/index.ts
@@ -1,0 +1,1 @@
+export { default as DeletePlanButton } from './DeletePlanButton';

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -23,3 +23,4 @@ export * from "./MainFood";
 export * from "./MainPlan";
 export * from "./AddPlanCheckbox";
 export * from "./SearchAddItem";
+export * from "./deletePlanButton";

--- a/client/src/hooks/deletePlan.ts
+++ b/client/src/hooks/deletePlan.ts
@@ -1,0 +1,20 @@
+import axios, { AxiosError } from 'axios';
+import { useMutation, useQueryClient } from 'react-query';
+import { Plan } from '../types';
+
+const deletePlan = async (id: string): Promise<Plan> => {
+	const response = await axios.delete(
+		`/api/v1/plans/?id=${id}`
+	);
+	return response.data;
+};
+export function useDeletePlan(id: string) {
+    const queryClient = useQueryClient();
+    return useMutation(() => deletePlan(id), {
+        onSuccess: () => {
+            queryClient.invalidateQueries("get-all-plan")
+        },
+        onError: (error: AxiosError) => {
+        alert(error);
+    }});
+}

--- a/client/src/hooks/deletePlan.ts
+++ b/client/src/hooks/deletePlan.ts
@@ -2,13 +2,13 @@ import axios, { AxiosError } from 'axios';
 import { useMutation, useQueryClient } from 'react-query';
 import { Plan } from '../types';
 
-const deletePlan = async (id: string): Promise<Plan> => {
+const deletePlan = async (id: string | undefined): Promise<Plan> => {
 	const response = await axios.delete(
 		`/api/v1/plans/?id=${id}`
 	);
 	return response.data;
 };
-export function useDeletePlan(id: string) {
+export function useDeletePlan(id: string | undefined) {
     const queryClient = useQueryClient();
     return useMutation(() => deletePlan(id), {
         onSuccess: () => {

--- a/client/src/hooks/getAllPlan.ts
+++ b/client/src/hooks/getAllPlan.ts
@@ -9,5 +9,5 @@ const getAllPlan = async (date: string): Promise<Plan[]> => {
 	return response.data.data;
 };
 export function useGetAllPlan(date: string) {
-	return useQuery("get-all-plan", () => getAllPlan(date));
+	return useQuery(["get-all-plan", date], ( { queryKey }) => getAllPlan(queryKey[1]));
 }

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -9,3 +9,4 @@ export * from "./getAllExercise";
 export * from "./getAllPlan";
 export * from "./getAllActivity";
 export * from "./postActivity";
+export * from "./deletePlan";

--- a/client/src/hooks/patchPlan.ts
+++ b/client/src/hooks/patchPlan.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
-import { useMutation } from 'react-query';
+import axios, { AxiosError } from 'axios';
+import { useMutation, useQueryClient } from 'react-query';
 import { Plan, PlanContent } from '../types';
 
 const patchPlan = async (date: string, id: string | undefined, plan: PlanContent): Promise<Plan> => {
@@ -9,5 +9,12 @@ const patchPlan = async (date: string, id: string | undefined, plan: PlanContent
 	return response.data;
 };
 export function usePatchPlan(date: string, id: string | undefined, plan: PlanContent) {
-    return useMutation(() => patchPlan(date, id, plan));
+	const queryClient = useQueryClient();
+    return useMutation(() => patchPlan(date, id, plan), {
+		onSuccess: () => {
+            queryClient.invalidateQueries("get-all-plan")
+        },
+        onError: (error: AxiosError) => {
+        alert(error);
+    }});
 }

--- a/client/src/hooks/patchPlan.ts
+++ b/client/src/hooks/patchPlan.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+import { useMutation } from 'react-query';
+import { Plan, PlanContent } from '../types';
+
+const patchPlan = async (date: string, id: string | undefined, plan: PlanContent): Promise<Plan> => {
+	const response = await axios.patch(
+		`/api/v1/plans/${date}?id=${id}`, plan
+	);
+	return response.data;
+};
+export function usePatchPlan(date: string, id: string | undefined, plan: PlanContent) {
+    return useMutation(() => patchPlan(date, id, plan));
+}

--- a/client/src/hooks/postPlan.ts
+++ b/client/src/hooks/postPlan.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { useMutation, useQueryClient } from 'react-query';
 import { Plan, PlanContent } from '../types';
 
@@ -12,6 +12,9 @@ export function usePostPlan(date: string, plan: PlanContent) {
     const queryClient = useQueryClient();
     return useMutation(() => postPlan(date, plan), {
         onSuccess: () => {
-        queryClient.invalidateQueries("get-all-plan");
+            queryClient.invalidateQueries("get-all-plan")
+        },
+        onError: (error: AxiosError) => {
+        alert(error);
     }});
 }

--- a/client/src/types/PlanContent.ts
+++ b/client/src/types/PlanContent.ts
@@ -1,4 +1,4 @@
 export interface PlanContent {
-    content: string;
-    isComplete: number;
+    content: string | undefined;
+    isComplete: number | undefined;
 }


### PR DESCRIPTION
계획 삭제, 수정 기능을 구현했습니다.
계획의 X버튼을 클릭하면 계획이 삭제되고 계획 get api가 호출됩니다.
계획의 체크박스를 클릭할 시 해당 계획 아이템에 line-through(중간선) 효과가 적용됩니다.
또한 해당 아이템의 isComplete가 0에서 1로, 1에서 0으로 바뀌고 계획 수정 api가 호출됩니다.
![image](https://github.com/elice-cookcook/eatnfit/assets/87300419/eb7be63e-6d76-4d32-a2de-a2260f1a063f)
(isComplete 1 => 0으로 변경)
변경된 아이템들의 상태는 새로고침 후에도 유지됩니다.

12/26 수정 =>
완료된 계획 삭제 후 완료되지 않은 다음 계획에도 삭제된 계획에 상태가 전달되는 현상을 수정하였습니다.
전역 date 변수로 api parameter를 변경했습니다.
완료된 계획의 글자색을 #ccc로 수정하였습니다.