### PR TITLE
식단 post & 이미지 url get api 구현

### DIFF
--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -22,3 +22,4 @@ export * from "./deletePlan";
 export * from "./patchExercise";
 export * from "./deleteExercise";
 export * from "./deletePlan";
+export * from "./postImage";

--- a/client/src/hooks/postImage.ts
+++ b/client/src/hooks/postImage.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+import { useMutation } from 'react-query';
+
+const postImage = async (image: FormData): Promise<string> => {
+	const response = await axios.post(
+		'/api/v1/images', image, {
+            headers: { 'Content-Type': 'multipart/form-data' },
+          }
+	);
+	return response.data.data;
+};
+export function usePostImage() {
+    return useMutation((image: FormData) => postImage(image), {
+        onError: () => {
+            console.log("error");
+        }
+    });
+}

--- a/client/src/hooks/postMeal.ts
+++ b/client/src/hooks/postMeal.ts
@@ -5,15 +5,17 @@ import { Meal } from '../types';
 
 const postMeal = async (date: string, meal: Meal): Promise<Meal> => {
 	const response = await axios.post(
-		`/api/v1/meals/${date}`, meal
+		`/api/v1/meals/${date}`, meal, {
+            headers: { 'Content-Type': 'application/json' },
+          }
 	);
 	return response.data;
 };
-export function usePostMeal(date: string, meal: Meal) {
+export function usePostMeal(date: string) {
     const navigate = useNavigate();
     const queryClient = useQueryClient();
 
-    return useMutation(() => postMeal(date, meal), {
+    return useMutation((meal: Meal) => postMeal(date, meal), {
         onSuccess: () => {
         navigate('/main');
         queryClient.invalidateQueries("get-all-meal");

--- a/client/src/hooks/postMeal.ts
+++ b/client/src/hooks/postMeal.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { useMutation, useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
+import { message } from "antd";
 import { Meal } from '../types';
 
 const postMeal = async (date: string, meal: Meal): Promise<Meal> => {
@@ -17,7 +18,12 @@ export function usePostMeal(date: string) {
 
     return useMutation((meal: Meal) => postMeal(date, meal), {
         onSuccess: () => {
-        navigate('/main');
-        queryClient.invalidateQueries("get-all-meal");
-    }});
+            message.success("식단 추가에 성공하였습니다.")
+            navigate('/main');
+            queryClient.invalidateQueries("get-all-meal");
+        },
+        onError: () => {
+            message.error("식단 추가에 실패하였습니다.");
+        }
+    });
 }

--- a/client/src/pages/FoodRecordPage/FoodRecordPage.tsx
+++ b/client/src/pages/FoodRecordPage/FoodRecordPage.tsx
@@ -27,6 +27,7 @@ import { FoodRecord } from "../../types";
 import { ROUTE } from "../../routes/Route";
 import { usePostMeal } from "../../hooks/postMeal";
 import { usePostImage } from "../../hooks";
+import { message } from "antd";
 
 export default function FoodRecordPage() {
   const meal = ["아침", "아점", "점심", "간식", "점저", "저녁", "야식"];
@@ -83,6 +84,10 @@ export default function FoodRecordPage() {
   const selectedFood = useSelector((state: RootState) => state.food);
   const handleAddFood = () => {
     const items: {item: string, count: number, kcal: number}[] = [];
+    if(selectedFood.length < 1) {
+      message.error("음식을 추가해주세요.");
+      return;
+    }
     selectedFood.forEach((item) => {
       items.push({
         item: item.name as string,

--- a/client/src/types/Meal.ts
+++ b/client/src/types/Meal.ts
@@ -1,17 +1,13 @@
 export interface Meal {
-    _id: string;
-    date: number;
-    user_id: string;
     time: number;
     meal_type: number;
     image_url: string;
     total_kcal: number;
-    items: [{
-        _id: string;
+    items: {
         item: string;
         count: number;
         kcal: number;
-    }],
+    }[],
     total_carbohydrate: number,
     total_fat: number,
     total_protein: number,


### PR DESCRIPTION
1. 이미지 업로드 시 postImage hook이 실행되고, 업로드된 이미지의 url을 리턴합니다.
<img width="716" alt="스크린샷 2024-01-01 오후 9 10 33" src="https://github.com/elice-cookcook/eatnfit/assets/87300419/b9101c98-bb47-43f9-91f5-ab12cc2247c8">

2. 등록 버튼 클릭 시 선택된 식단이 post됩니다.
<img width="618" alt="스크린샷 2024-01-01 오후 9 15 08" src="https://github.com/elice-cookcook/eatnfit/assets/87300419/5e4460f3-e3fc-4353-87cc-e4df469149c8">

현재 식단 get api가 제대로 연동되지 않아 등록된 식단을 확인할 수는 없으나 network 탭에서 등록된 식단을 확인 가능합니다.
+) 사진 등록 후 음식 검색하기 페이지에 진입하면 등록했던 사진이 사라지는 이슈가 있습니다.
해당 현상은 추후 식단 수정 기능 구현에서 해결 해보겠습니다.