### PR TITLE
식단 / 운동 기록에서 음식/운동 추가 후 돌아왔을 때 기존 내용 삭제되는 이슈 해결

### DIFF
--- a/client/src/components/CloseBtn/CloseBtn.tsx
+++ b/client/src/components/CloseBtn/CloseBtn.tsx
@@ -1,13 +1,18 @@
 import { useLocation, useNavigate } from "react-router-dom";
 import CloseImage from "../../img/close.png";
-import { RootState, setFood } from "../../redux";
+import {
+  RootState,
+  setFood,
+  setMealRecord,
+  setExerciseRecord,
+} from "../../redux";
 import { useDispatch, useSelector } from "react-redux";
 import { ROUTE } from "../../routes/Route";
 
 interface CloseBtnProps {
   type?: string;
 }
-const Close = ({type}: CloseBtnProps) => {
+const Close = ({ type }: CloseBtnProps) => {
   const nav = useNavigate();
   const dispatch = useDispatch();
   const location = useLocation();
@@ -15,16 +20,19 @@ const Close = ({type}: CloseBtnProps) => {
     (state: RootState) => state.activeDay.activeDay
   );
   const handleNavigate = () => {
-    switch(type) {
-      case 'exerciseSearch' : {
+    switch (type) {
+      case "exerciseSearch": {
         nav(ROUTE.EXERCISE_RECORD_PAGE.link);
         break;
       }
-      case 'foodSearch': {
+      case "foodSearch": {
         if (location.state.isEdit) {
-          nav(`${ROUTE.FOOD_DETAIL_PAGE.link}/${activeDay}/${location.state.idx}`, {
-            state: { isEdit: location.state.isEdit },
-          });
+          nav(
+            `${ROUTE.FOOD_DETAIL_PAGE.link}/${activeDay}/${location.state.idx}`,
+            {
+              state: { isEdit: location.state.isEdit },
+            }
+          );
         } else {
           nav(ROUTE.FOOD_RECORD_PAGE.link);
         }
@@ -33,9 +41,24 @@ const Close = ({type}: CloseBtnProps) => {
       default: {
         nav(ROUTE.MAIN_PAGE.link);
         dispatch(setFood([]));
+        dispatch(
+          setMealRecord({
+            image_url: "",
+            meal_type: 0,
+          })
+        );
+        dispatch(
+          setExerciseRecord({
+            exercise_type: 0,
+            exercise_part: 0,
+            exercise_strength: 0,
+            exercise_name: "",
+            exercise_time: 0
+          })
+        );
       }
     }
-  }
+  };
   return (
     <img
       src={CloseImage}

--- a/client/src/components/FoodRecordImage/FoodRecordImage.tsx
+++ b/client/src/components/FoodRecordImage/FoodRecordImage.tsx
@@ -1,6 +1,8 @@
 import React, { Dispatch, MutableRefObject, useRef, useState } from "react";
 import { usePostImage } from "../../hooks";
 import { AddImg, SelectImage } from "./styles";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState, setMealRecord } from "../../redux";
 
 interface FoodRecordImageProps {
   imageRef?: MutableRefObject<HTMLImageElement | null>;
@@ -20,6 +22,10 @@ export default function FoodRecordImage({
       fileInputRef.current.click();
     }
   };
+  const dispatch = useDispatch();
+  const existedMealType = useSelector(
+    (state: RootState) => state.mealRecord.meal_type
+  );
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = e.target.files && e.target.files[0];
     if (selectedFile) {
@@ -32,6 +38,12 @@ export default function FoodRecordImage({
           postImage(formData, {
             onSuccess: (response) => {
               setImageUrl(response);
+              dispatch(
+                setMealRecord({
+                  image_url: response,
+                  meal_type: existedMealType,
+                })
+              );
             },
           });
         }

--- a/client/src/components/SelectBtn/SelectBtn.tsx
+++ b/client/src/components/SelectBtn/SelectBtn.tsx
@@ -1,4 +1,6 @@
+import { useDispatch, useSelector } from "react-redux";
 import { WrappedSelectBtn } from "./styles";
+import { RootState, setMealRecord } from "../../redux";
 
 type SelectBtnProps = {
   items: string[];
@@ -7,8 +9,18 @@ type SelectBtnProps = {
 };
 
 function SelectBtn({ items, value, onChange }: SelectBtnProps) {
+  const dispatch = useDispatch();
+  const existedImageUrl = useSelector(
+    (state: RootState) => state.mealRecord.image_url
+  );
   const handleOnClickBtn = (index: number) => {
     onChange(index);
+    dispatch(
+      setMealRecord({
+        image_url: existedImageUrl,
+        meal_type: index,
+      })
+    );
   };
 
   return items.map((item, index) => (

--- a/client/src/pages/ExerciseRecordPage/ExerciseRecordPage.tsx
+++ b/client/src/pages/ExerciseRecordPage/ExerciseRecordPage.tsx
@@ -15,12 +15,11 @@ import {
   exerciseStrengthArr,
   exerciseTypeArr,
 } from "../../lib";
-import { useState } from "react";
-// import moment from "moment";
+import { useEffect, useState } from "react";
 import { usePostExercise, useGetActivityByName } from "../../hooks";
 import { ExerciseContent } from "../../types";
-import { useSelector } from "react-redux";
-import { RootState } from "../../redux";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState, setExerciseRecord } from "../../redux";
 import { ROUTE } from "../../routes/Route";
 import { message } from "antd";
 import { format } from "date-fns";
@@ -33,10 +32,24 @@ export default function ExerciseRecordPage() {
   const activeDay = useSelector(
     (state: RootState) => state.activeDay.activeDay
   );
-  const [exerciseTime, setExerciseTime] = useState<number>(0);
-  const [exerciseType, setExerciseType] = useState<number>(0);
-  const [exercisePart, setExercisePart] = useState<number>(0);
-  const [exerciseStrength, setExerciseStrength] = useState<number>(0);
+  const existedExerciseTime = useSelector(
+    (state: RootState) => state.exerciseRecord.exercise_time
+  );
+  const existedExerciseType = useSelector(
+    (state: RootState) => state.exerciseRecord.exercise_type
+  );
+  const existedExercisePart = useSelector(
+    (state: RootState) => state.exerciseRecord.exercise_part
+  );
+  const existedExerciseStrength = useSelector(
+    (state: RootState) => state.exerciseRecord.exercise_strength
+  );
+  const [exerciseTime, setExerciseTime] = useState<number>(existedExerciseTime);
+  const [exerciseType, setExerciseType] = useState<number>(existedExerciseType);
+  const [exercisePart, setExercisePart] = useState<number>(existedExercisePart);
+  const [exerciseStrength, setExerciseStrength] = useState<number>(
+    existedExerciseStrength
+  );
 
   const { data } = useGetActivityByName(exerciseName); // 액티비티 정보 불러오기
   const unitKcal = data?.kcal || 0;
@@ -68,7 +81,26 @@ export default function ExerciseRecordPage() {
       postExercise();
     }
   };
-
+  const dispatch = useDispatch();
+  useEffect(() => {
+    console.log(exerciseTime);
+    dispatch(
+      setExerciseRecord({
+        exercise_name: exerciseName,
+        exercise_time: exerciseTime,
+        exercise_type: exerciseType,
+        exercise_part: exercisePart,
+        exercise_strength: exerciseStrength,
+      })
+    );
+  }, [
+    dispatch,
+    exerciseName,
+    exercisePart,
+    exerciseStrength,
+    exerciseTime,
+    exerciseType,
+  ]);
   return (
     <Wrap>
       <RecordHeader>
@@ -94,7 +126,7 @@ export default function ExerciseRecordPage() {
           <Title>운동 시간</Title>
           <Input
             value={exerciseTime || ""}
-            onChange={(e) => setExerciseTime(parseInt(e.target.value))}
+            onChange={(e) => setExerciseTime(Number(e.target.value))}
             type="number"
           ></Input>
           <span>분</span>

--- a/client/src/pages/FoodDetailPage/FoodDetailPage.tsx
+++ b/client/src/pages/FoodDetailPage/FoodDetailPage.tsx
@@ -25,7 +25,7 @@ import {
 } from "../../components";
 import { useRef, useState, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { RootState, setFood } from "../../redux";
+import { RootState, setFood, setMealRecord } from "../../redux";
 import {
   useGetAllMeal,
   useGetFoodByName,
@@ -44,6 +44,12 @@ export default function FoodDetailPage() {
   const location = useLocation();
   const [dataId, setDataId] = useState("");
   const imageRef = useRef<HTMLImageElement | null>(null);
+  const existedImageUrl = useSelector(
+    (state: RootState) => state.mealRecord.image_url
+  );
+  const existedMealType = useSelector(
+    (state: RootState) => state.mealRecord.meal_type
+  );
   const [time, setTime] = useState<string>("");
   const [mealType, setMealType] = useState<number>(0);
   const [edit, setEdit] = useState(location?.state?.isEdit || false);
@@ -81,21 +87,20 @@ export default function FoodDetailPage() {
     if (data && date && (idx || idx === "0")) {
       const target = data[parseInt(idx)];
       setDataId(target._id);
-      setImageUrl(target.image_url);
+      setImageUrl(existedImageUrl === "" ? target.image_url : existedImageUrl);
       setTime(
         String(target.time).slice(0, 2) +
           "시 " +
           String(target.time).slice(2) +
           "분"
       );
-      setMealType(target.meal_type);
+      setMealType(existedMealType === 0 ? target.meal_type : existedMealType);
       setTotalKcal(target.total_kcal);
       setTotalProtein(target.total_protein);
       setTotalCarbohydrate(target.total_carbohydrate);
       setTotalFat(target.total_fat);
     }
-  }, [data, idx, date, edit]);
-
+  }, [data, idx, date, edit, existedImageUrl, existedMealType]);
   const newFood: {
     item: string;
     count: number;
@@ -127,6 +132,12 @@ export default function FoodDetailPage() {
   const handlePatchMeal = () => {
     toggleEdit();
     patchMeal.mutate();
+    dispatch(
+      setMealRecord({
+        image_url: "",
+        meal_type: 0,
+      })
+    );
   };
 
   const handleDeleteMeal = () => {

--- a/client/src/pages/FoodRecordPage/FoodRecordPage.tsx
+++ b/client/src/pages/FoodRecordPage/FoodRecordPage.tsx
@@ -18,8 +18,8 @@ import {
   FoodRecordCalory,
 } from "../../components";
 import { useState, useEffect, useRef } from "react";
-import { useSelector } from "react-redux";
-import { RootState } from "../../redux";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState, setMealRecord } from "../../redux";
 import { FoodRecord } from "../../types";
 import { ROUTE } from "../../routes/Route";
 import { usePostMeal } from "../../hooks";
@@ -30,11 +30,17 @@ import { ko } from "date-fns/locale";
 export default function FoodRecordPage() {
   const meal = ["아침", "아점", "점심", "간식", "점저", "저녁", "야식"];
   const [time, setTime] = useState<string>("");
-  const [mealType, setMealType] = useState(0); // 음식 타입
+  const existedImageUrl = useSelector(
+    (state: RootState) => state.mealRecord.image_url
+  );
+  const existedMealType = useSelector(
+    (state: RootState) => state.mealRecord.meal_type
+  );
+  const [mealType, setMealType] = useState(existedMealType); // 음식 타입
   const activeDay = useSelector(
     (state: RootState) => state.activeDay.activeDay
   );
-  const [imageUrl, setImageUrl] = useState("");
+  const [imageUrl, setImageUrl] = useState(existedImageUrl);
   const { mutate } = usePostMeal(format(activeDay, "yyyyMMdd"));
 
   // 시간
@@ -49,7 +55,7 @@ export default function FoodRecordPage() {
     const minutes = now.getMinutes().toString().padStart(2, "0");
     return `${hours}:${minutes}`;
   };
-
+  const dispatch = useDispatch();
   const selectedFood = useSelector((state: RootState) => state.food);
   const imageRef = useRef<HTMLImageElement | null>(null);
 
@@ -66,6 +72,12 @@ export default function FoodRecordPage() {
         kcal: item.calory as number,
       });
     });
+    dispatch(
+      setMealRecord({
+        image_url: "",
+        meal_type: 0,
+      })
+    );
     mutate({
       items: items,
       time: Number(getCurrentTime().replace(":", "")),

--- a/client/src/redux/actions/exerciseRecordAction.ts
+++ b/client/src/redux/actions/exerciseRecordAction.ts
@@ -1,0 +1,15 @@
+export const SET_EXERCISE_RECORD = "SET_EXERCISE_RECORD";
+
+export const setExerciseRecord = (
+    exerciseRecord: {
+        exercise_name: string,
+        exercise_time: number,
+        exercise_type: number,
+        exercise_part: number,
+        exercise_strength: number,
+    }) => {
+  return {
+    type: SET_EXERCISE_RECORD,
+    payload: exerciseRecord,
+  };
+};

--- a/client/src/redux/actions/index.ts
+++ b/client/src/redux/actions/index.ts
@@ -1,3 +1,5 @@
 export * from "./menuAction";
 export * from "./activeDayAction";
 export * from "./foodAction";
+export * from "./mealRecordAction";
+export * from "./exerciseRecordAction";

--- a/client/src/redux/actions/mealRecordAction.ts
+++ b/client/src/redux/actions/mealRecordAction.ts
@@ -1,0 +1,12 @@
+export const SET_MEAL_RECORD = "SET_MEAL_RECORD";
+
+export const setMealRecord = (
+    mealRecord: {
+        image_url: string,
+        meal_type: number,
+    }) => {
+  return {
+    type: SET_MEAL_RECORD,
+    payload: mealRecord,
+  };
+};

--- a/client/src/redux/reducers/exerciseRecordReducer.ts
+++ b/client/src/redux/reducers/exerciseRecordReducer.ts
@@ -1,0 +1,35 @@
+import { SET_EXERCISE_RECORD, setExerciseRecord } from "../actions";
+
+const initialState: {
+    exercise_name: string,
+    exercise_time: number,
+    exercise_type: number,
+    exercise_part: number,
+    exercise_strength: number,
+} = {
+    exercise_name: '',
+    exercise_time: 0,
+    exercise_type: 0,
+    exercise_part: 0,
+    exercise_strength: 0,
+}
+
+type exerciseRecordActionType = ReturnType<typeof setExerciseRecord>;
+
+const exerciseRecordReducer = (state = initialState, action: exerciseRecordActionType) => {
+  switch (action.type) {
+    case SET_EXERCISE_RECORD:
+        return {
+        ...state,
+        exercise_name: action.payload.exercise_name,
+        exercise_time: action.payload.exercise_time,
+        exercise_type: action.payload.exercise_type,
+        exercise_part: action.payload.exercise_part,
+        exercise_strength: action.payload.exercise_strength,
+    };
+    default:
+        return state;
+    }
+};
+
+export default exerciseRecordReducer;

--- a/client/src/redux/reducers/index.ts
+++ b/client/src/redux/reducers/index.ts
@@ -2,11 +2,15 @@ import { combineReducers } from "redux";
 import menuReducer from "./menuReducer";
 import activeDayReducer from "./activeDayReducer";
 import foodReducer from "./foodReducer";
+import mealRecordReducer from "./mealRecordReducer";
+import exerciseRecordReducer from "./exerciseRecordReducer";
 
 const rootReducer = combineReducers({
   menu: menuReducer,
   activeDay: activeDayReducer,
   food: foodReducer,
+  mealRecord: mealRecordReducer,
+  exerciseRecord: exerciseRecordReducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/client/src/redux/reducers/mealRecordReducer.ts
+++ b/client/src/redux/reducers/mealRecordReducer.ts
@@ -1,0 +1,26 @@
+import { SET_MEAL_RECORD, setMealRecord } from "../actions";
+
+const initialState: {
+    image_url: string,
+    meal_type: number,
+} = {
+    image_url: '',
+    meal_type: 0,
+}
+
+type mealRecordActionType = ReturnType<typeof setMealRecord>;
+
+const mealRecordReducer = (state = initialState, action: mealRecordActionType) => {
+  switch (action.type) {
+    case SET_MEAL_RECORD:
+        return {
+        ...state,
+        image_url: action.payload.image_url,
+        meal_type: action.payload.meal_type,
+    };
+    default:
+        return state;
+    }
+};
+
+export default mealRecordReducer;


### PR DESCRIPTION
1. 식단 추가 / 수정에서 imageUrl, mealType을 mealRecord reducer에 저장하여 redux로 관리할 수 있도록 수정했습니다.
2. 운동 추가 / 수정에서 exerciseName, exerciseTime, exerciseType, exercisePart, exerciseStrength을 exerciseRecord reducer에 저장하여 redux로 관리할 수 있도록 수정했습니다.